### PR TITLE
feat: 필터 버튼 컴포넌트 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,12 @@
       "name": "livetrip-refactor",
       "version": "0.1.0",
       "dependencies": {
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
         "next": "15.5.15",
         "react": "19.1.0",
-        "react-dom": "19.1.0"
+        "react-dom": "19.1.0",
+        "tailwind-merge": "^3.5.0"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -2962,6 +2965,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
+      }
+    },
     "node_modules/clean-regexp": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/clean-regexp/-/clean-regexp-1.0.0.tgz",
@@ -2990,6 +3005,15 @@
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -7931,6 +7955,16 @@
       },
       "funding": {
         "url": "https://opencollective.com/synckit"
+      }
+    },
+    "node_modules/tailwind-merge": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.5.0.tgz",
+      "integrity": "sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
       }
     },
     "node_modules/tailwindcss": {

--- a/package.json
+++ b/package.json
@@ -13,9 +13,12 @@
     "format:check": "prettier --check ."
   },
   "dependencies": {
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
     "next": "15.5.15",
     "react": "19.1.0",
-    "react-dom": "19.1.0"
+    "react-dom": "19.1.0",
+    "tailwind-merge": "^3.5.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -18,10 +18,14 @@
 
   --color-primary-100: rgb(229, 243, 255);
   --color-primary-500: rgb(61, 158, 242);
+  --color-primary-hover: rgb(91, 178, 255);
+
+  --color-label-hover: rgb(209, 233, 255);
 
   --color-gray-25: rgb(248, 248, 248);
   --color-gray-50: rgb(237, 238, 242);
   --color-gray-100: rgb(224, 224, 229);
+  --color-gray-150: rgb(216, 216, 216);
   --color-gray-200: rgb(198, 200, 207);
   --color-gray-300: rgb(179, 180, 188);
   --color-gray-400: rgb(159, 160, 167);
@@ -29,6 +33,7 @@
   --color-gray-600: rgb(112, 113, 119);
   --color-gray-700: rgb(93, 93, 97);
   --color-gray-800: rgb(73, 73, 76);
+  --color-gray-875: rgb(51, 51, 51);
   --color-gray-900: rgb(50, 50, 54);
   --color-gray-950: rgb(31, 31, 34);
 

--- a/src/components/button/ButtonBase.tsx
+++ b/src/components/button/ButtonBase.tsx
@@ -24,20 +24,20 @@ const typo = {
 
 const toneClassMap = {
   primary: {
-    normal:
-      'bg-primary-500 text-white hover:bg-primary-hover disabled:bg-gray-200 disabled:text-gray-50',
     active:
+      'bg-primary-500 text-white hover:bg-primary-hover disabled:bg-gray-200 disabled:text-gray-50',
+    normal:
       'bg-white text-gray-600 border border-gray-200 disabled:bg-white disabled:text-gray-200 disabled:border-gray-200',
   },
   secondary: {
-    normal:
-      'bg-primary-500 text-white hover:bg-primary-hover disabled:bg-white disabled:text-gray-200 disabled:border disabled:border-gray-200',
     active:
+      'bg-primary-500 text-white hover:bg-primary-hover disabled:bg-white disabled:text-gray-200 disabled:border disabled:border-gray-200',
+    normal:
       'bg-white text-gray-600 border border-gray-200 disabled:bg-white disabled:text-gray-200 disabled:border-gray-200',
   },
   label: {
-    normal: 'bg-primary-100 text-gray-950 hover:bg-label-hover',
-    active: 'text-gray-600',
+    active: 'bg-primary-100 text-gray-950 hover:bg-label-hover',
+    normal: 'text-gray-600',
   },
 } satisfies Record<ButtonVariant, Record<ButtonTone, string>>;
 

--- a/src/components/button/ButtonBase.tsx
+++ b/src/components/button/ButtonBase.tsx
@@ -1,0 +1,70 @@
+import type { ComponentPropsWithoutRef, ReactNode } from 'react';
+import { cx } from '@/lib/cx';
+
+type ButtonVariant = 'primary' | 'secondary' | 'label';
+type ButtonTone = 'normal' | 'active';
+
+interface ButtonBaseProps extends ComponentPropsWithoutRef<'button'> {
+  variant: ButtonVariant;
+  tone: ButtonTone;
+  children: ReactNode;
+}
+
+const shapes = {
+  primary: 'h-10 md:h-12 lg:h-14 rounded-xl md:rounded-2xl',
+  secondary: 'h-8 md:h-12 lg:h-14 rounded-xl md:rounded-2xl',
+  label: 'h-10 md:h-12 lg:h-14 rounded-xl md:rounded-2xl',
+};
+
+const typo = {
+  primary: 'text-14 md:text-16 font-bold',
+  secondary: 'text-14 md:text-16 font-medium',
+  label: 'text-14 md:text-16 font-medium',
+};
+
+const toneClassMap = {
+  primary: {
+    normal:
+      'bg-primary-500 text-white hover:bg-primary-hover disabled:bg-gray-200 disabled:text-gray-50',
+    active:
+      'bg-white text-gray-600 border border-gray-200 disabled:bg-white disabled:text-gray-200 disabled:border-gray-200',
+  },
+  secondary: {
+    normal:
+      'bg-primary-500 text-white hover:bg-primary-hover disabled:bg-white disabled:text-gray-200 disabled:border disabled:border-gray-200',
+    active:
+      'bg-white text-gray-600 border border-gray-200 disabled:bg-white disabled:text-gray-200 disabled:border-gray-200',
+  },
+  label: {
+    normal: 'bg-primary-100 text-gray-950 hover:bg-label-hover',
+    active: 'text-gray-600',
+  },
+} satisfies Record<ButtonVariant, Record<ButtonTone, string>>;
+
+const baseClassName =
+  'inline-flex w-full items-center justify-center gap-1 text-center select-none transition-colors motion-safe:transition-transform motion-safe:transition-shadow duration-200 ease-[cubic-bezier(0.25,0.1,0.25,1)] enabled:hover:-translate-y-0.5 enabled:hover:shadow-lg enabled:active:translate-y-0 enabled:active:shadow [&>img]:h-4 [&>img]:w-4 md:[&>img]:h-6 md:[&>img]:w-6 lg:[&>img]:h-6 lg:[&>img]:w-6';
+
+export default function ButtonBase({
+  variant,
+  tone,
+  type = 'button',
+  className,
+  children,
+  ...rest
+}: ButtonBaseProps) {
+  return (
+    <button
+      type={type}
+      className={cx(
+        baseClassName,
+        shapes[variant],
+        typo[variant],
+        toneClassMap[variant][tone],
+        className
+      )}
+      {...rest}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/components/button/FilterButton.tsx
+++ b/src/components/button/FilterButton.tsx
@@ -1,0 +1,37 @@
+import type { ComponentPropsWithoutRef, ReactNode } from 'react';
+import { cx } from '@/lib/cx';
+
+interface FilterButtonProps extends Omit<
+  ComponentPropsWithoutRef<'button'>,
+  'children'
+> {
+  selected?: boolean;
+  children?: ReactNode;
+}
+
+const filterClassName =
+  'inline-flex h-9 w-full items-center justify-center gap-1 rounded-full text-center select-none text-14 font-bold transition-colors motion-safe:transition-transform motion-safe:transition-shadow duration-200 ease-[cubic-bezier(0.25,0.1,0.25,1)] enabled:hover:-translate-y-0.5 enabled:hover:shadow-lg enabled:active:translate-y-0 enabled:active:shadow md:text-16 md:h-11 [&_svg]:shrink-0';
+
+export default function FilterButton({
+  selected = false,
+  type = 'button',
+  className,
+  children,
+  ...rest
+}: FilterButtonProps) {
+  return (
+    <button
+      type={type}
+      className={cx(
+        filterClassName,
+        selected
+          ? 'bg-gray-875 text-white hover:bg-gray-800 [&_svg]:fill-white'
+          : 'border-gray-150 border bg-white text-gray-950',
+        className
+      )}
+      {...rest}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/components/button/LabelButton.tsx
+++ b/src/components/button/LabelButton.tsx
@@ -1,0 +1,11 @@
+import type { ComponentPropsWithoutRef } from 'react';
+import ButtonBase from './ButtonBase';
+
+type LabelButtonProps = Omit<
+  ComponentPropsWithoutRef<typeof ButtonBase>,
+  'variant'
+>;
+
+export default function LabelButton({ ...props }: LabelButtonProps) {
+  return <ButtonBase variant='label' {...props} />;
+}

--- a/src/components/button/PrimaryButton.tsx
+++ b/src/components/button/PrimaryButton.tsx
@@ -1,0 +1,11 @@
+import type { ComponentPropsWithoutRef } from 'react';
+import ButtonBase from './ButtonBase';
+
+type PrimaryButtonProps = Omit<
+  ComponentPropsWithoutRef<typeof ButtonBase>,
+  'variant' | 'tone'
+>;
+
+export default function PrimaryButton({ ...props }: PrimaryButtonProps) {
+  return <ButtonBase variant='primary' tone='normal' {...props} />;
+}

--- a/src/components/button/PrimaryButton.tsx
+++ b/src/components/button/PrimaryButton.tsx
@@ -7,5 +7,5 @@ type PrimaryButtonProps = Omit<
 >;
 
 export default function PrimaryButton({ ...props }: PrimaryButtonProps) {
-  return <ButtonBase variant='primary' tone='normal' {...props} />;
+  return <ButtonBase variant='primary' tone='active' {...props} />;
 }

--- a/src/components/button/SecondaryButton.tsx
+++ b/src/components/button/SecondaryButton.tsx
@@ -1,0 +1,11 @@
+import type { ComponentPropsWithoutRef } from 'react';
+import ButtonBase from './ButtonBase';
+
+type SecondaryButtonProps = Omit<
+  ComponentPropsWithoutRef<typeof ButtonBase>,
+  'variant'
+>;
+
+export default function SecondaryButton({ ...props }: SecondaryButtonProps) {
+  return <ButtonBase variant='secondary' {...props} />;
+}

--- a/src/lib/cx.ts
+++ b/src/lib/cx.ts
@@ -1,0 +1,13 @@
+import { cx as cvaCX } from 'class-variance-authority';
+import type { ClassValue } from 'clsx';
+import { extendTailwindMerge } from 'tailwind-merge';
+
+const twMerge = extendTailwindMerge({
+  extend: {
+    theme: {
+      text: ['10', '12', '13', '14', '16', '18', '20', '24', '32', '14-body', '16-body', '18-body', '20-body'],
+    },
+  },
+});
+
+export const cx = (...inputs: ClassValue[]): string => twMerge(cvaCX(inputs));


### PR DESCRIPTION
## 작업 배경

라이브트림에서 사용되는 필터 버튼 UI를 공통 컴포넌트로 분리했습니다.
다른 버튼과 UI, 기능적으로 차이가 있다고 판단하여, 기본 버튼 베이스 컴포넌트를 사용하지 않았습니다.

## 주요 변경 사항

- 필터 버튼 컴포넌트 추가

## 구현 포인트

- 색상, 높이, 호버 효과는 동일하게 사용합니다.
- 아이콘 버튼, 링크형 버튼, 사이즈 확장, className 확장이 가능하도록 커스터마이징 및 재사용이 가능합니다.

## 기대효과

- 필터 버튼 UI의 일관성 확보
- 기본 버튼과 차이를 두고 구현하여 추후 확장 시 독립성 확보

## 확인 포인트

- 기본/선택 스타일이 정상적으로 적용되는지
- 반응형 구간에서 높이와 스타일이 깨지지 않는지
- `className` 추가 전달 시 스타일 병합이 정상 동작하는지

## 기본 사용법

```ts
  <FilterButton selected aria-label='선택된 필터'>
    선택된 필터
  </FilterButton>

  <FilterButton aria-label='필터'>필터</FilterButton>
```

className props를 추가하여, 추가 스타일 확장 및 커스터마이징이 가능합니다.

## 스크린샷

```ts
  <section className='space-y-3'>
    <h2 className='text-16 font-semibold text-gray-950'>FilterButton</h2>
    <FilterButton selected aria-label='선택된 필터'>
      선택된 필터
    </FilterButton>
    <FilterButton aria-label='필터'>필터</FilterButton>
  </section>
```

<img width="432" height="165" alt="image" src="https://github.com/user-attachments/assets/d94c3f0e-5a78-4b1c-bff9-cf786f0b3bb5" />
